### PR TITLE
Implemented fullcalendar 'select' callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ Source: [https://fullcalendar.io/docs/eventsSet](https://fullcalendar.io/docs/ev
 | -------- | :--------------------: | ------------------------------------------------------ |
 | events   | [`Event[]`](#EventApi) | An array of events. It contains every event in memory. |
 
+#### `select`
+
+Triggered when a date/time selection is made.
+
+Source: [https://fullcalendar.io/docs/select-callback](https://fullcalendar.io/docs/select-callback)
+
+| Property |            Type            | Description                                                                                                          |
+| -------- | :------------------------: | -------------------------------------------------------------------------------------------------------------------- |
+| allDay   |         `boolean`          | `true` or `false` whether the selection happened on all-day cells.                                                   |
+| start    |          `string`          | a date indicating the beginning of the selection in [ISO8601 string](https://en.wikipedia.org/wiki/ISO_8601) format. |
+| end.     |          `string`          | a date indicating the end of the selection in [ISO8601 string](https://en.wikipedia.org/wiki/ISO_8601) format.       |
+| view     |     [`View`](#ViewApi)     | The current view.                                                                                                    |
+| resource | [`Resource`](#ResourceApi) | If the current view is a resource-view, the resource that owns this selection.                                       |
+
 ### Types
 
 #### <a name="EventApi"></a>`Event`

--- a/streamlit_calendar/__init__.py
+++ b/streamlit_calendar/__init__.py
@@ -72,9 +72,10 @@ def calendar(
         nor use in commercial production websites or products if
         no license_key is provided.
     callbacks: str[]
-        List of callback to enable. Set to empty list to disable all callbacks.
+        List of callback to enable. By default all callbacks are enabled. 
+        Set to empty list to disable all callbacks.
         List may contain 'dateClick', 'eventClick', 'eventChange', 'eventsSet'
-        and 'select'
+        and 'select'.
     key: str or None
         An optional key that uniquely identifies this component. If this set to
         None, and the component's arguments are changed, the component will
@@ -272,6 +273,7 @@ if not _RELEASE:
         "editable": "true",
         "navLinks": "true",
         "resources": calendar_resources,
+        "selectable": "true",
     }
 
     if "resource" in mode:

--- a/streamlit_calendar/__init__.py
+++ b/streamlit_calendar/__init__.py
@@ -48,7 +48,7 @@ def calendar(
     events=[],
     options={},
     custom_css="",
-    callbacks=["dateClick", "eventClick", "eventChange", "eventsSet"],
+    callbacks=["dateClick", "eventClick", "eventChange", "eventsSet", "select"],
     license_key="CC-Attribution-NonCommercial-NoDerivatives",
     key=None,
 ):
@@ -74,6 +74,7 @@ def calendar(
     callbacks: str[]
         List of callback to enable. Set to empty list to disable all callbacks.
         List may contain 'dateClick', 'eventClick', 'eventChange', 'eventsSet'
+        and 'select'
     key: str or None
         An optional key that uniquely identifies this component. If this set to
         None, and the component's arguments are changed, the component will
@@ -82,7 +83,8 @@ def calendar(
     Returns
     -------
     dict
-        State value from dateClick, eventClick, eventChange and eventsSet callback
+        State value from dateClick, eventClick, eventChange, eventsSet
+        and select callback
 
     """
     # Call through to our private component function. Arguments we pass here

--- a/streamlit_calendar/frontend/src/components/Calendar.tsx
+++ b/streamlit_calendar/frontend/src/components/Calendar.tsx
@@ -168,9 +168,6 @@ const CalendarFC: React.FC<Props> = ({
         dateClick={
           callbacks?.includes("dateClick") ? handleDateClick : undefined
         }
-        select={
-          callbacks?.includes("select") ? handleSelect : undefined
-        }
         eventClick={
           callbacks?.includes("eventClick") ? handleEventClick : undefined
         }
@@ -179,6 +176,9 @@ const CalendarFC: React.FC<Props> = ({
         }
         eventsSet={
           callbacks?.includes("eventsSet") ? handleEventsSet : undefined
+        }
+        select={
+          callbacks?.includes("select") ? handleSelect : undefined
         }
         {...options}
       />

--- a/streamlit_calendar/frontend/src/components/Calendar.tsx
+++ b/streamlit_calendar/frontend/src/components/Calendar.tsx
@@ -14,6 +14,7 @@ import timelinePlugin from "@fullcalendar/timeline" // premium
 
 import {
   CalendarOptions,
+  DateSelectArg,
   EventApi,
   EventChangeArg,
   EventClickArg,
@@ -34,6 +35,8 @@ import {
   EventClickValue,
   EventsSetComponentValue,
   EventsSetValue,
+  SelectComponentValue,
+  SelectValue,
   ViewValue,
 } from "../types/Calendar.type"
 
@@ -135,6 +138,23 @@ const CalendarFC: React.FC<Props> = ({
     Streamlit.setComponentValue(componentValue)
   }
 
+  const handleSelect = (arg: DateSelectArg) => {
+    const select: SelectValue = {
+      allDay: arg.allDay,
+      start: arg.start.toISOString(),
+      end: arg.end.toISOString(),
+      view: getViewValue(arg.view),
+      resource: arg.resource?.toJSON(),
+    }
+
+    const componentValue: SelectComponentValue = {
+      callback: "select",
+      select,
+    }
+
+    Streamlit.setComponentValue(componentValue)
+  }
+
   React.useEffect(() => {
     Streamlit.setFrameHeight()
   }, [])
@@ -147,6 +167,9 @@ const CalendarFC: React.FC<Props> = ({
         schedulerLicenseKey={license_key}
         dateClick={
           callbacks?.includes("dateClick") ? handleDateClick : undefined
+        }
+        select={
+          callbacks?.includes("select") ? handleSelect : undefined
         }
         eventClick={
           callbacks?.includes("eventClick") ? handleEventClick : undefined

--- a/streamlit_calendar/frontend/src/types/Calendar.type.ts
+++ b/streamlit_calendar/frontend/src/types/Calendar.type.ts
@@ -62,6 +62,14 @@ export type EventsSetValue = {
   events: EventValue[]
 }
 
+export type SelectValue = {
+  allDay: boolean
+  start: string;
+  end: string;
+  view: ViewValue
+  resource?: ResourceValue
+}
+
 export type DateClickComponentValue = {
   callback: "dateClick"
   dateClick: DateClickValue
@@ -82,10 +90,16 @@ export type EventsSetComponentValue = {
   eventsSet: EventsSetValue
 }
 
+export type SelectComponentValue = {
+  callback: "select"
+  select: SelectValue
+}
+
 export type ComponentValue =
   | DateClickComponentValue
   | EventClickComponentValue
   | EventChangeComponentValue
   | EventsSetComponentValue
+  | SelectComponentValue
 
 export type Callback = ComponentValue["callback"]


### PR DESCRIPTION
Hi Muhammad,

Thank you for creating this Streamlit component, and adding custom-css support (which was actually requested by a colleague of mine :). Great work!

I was trying to use the fullcalendar functionality of making a selection by clicking and dragging in the empty space of the calendar, like this:
![image](https://github.com/im-perativa/streamlit-calendar/assets/43676624/9fded364-130a-460f-b118-c4ee52b8f519)
(Note that "selectable" should be True in the calendar options)

While a 'select' callback is available in fullcalendar (https://fullcalendar.io/docs/select-callback), I noticed that your Streamlit wrapper component didn't provide an implementation for it yet.

As it seemed pretty straightforward, I took the liberty of implementing it and thought you might appreciate the contribution as a pull request. I build upon your most recent release (2 days ago) and followed your style of coding (return format and variable naming). I tested it, and it works flawlessly.

Do you think you could include this in the next release and python package so we can use it out-of-the-box?

Best,
Max
