### PR TITLE
Implemented fullcalendar 'datesSet' callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ Source: [https://fullcalendar.io/docs/dateClick](https://fullcalendar.io/docs/da
 | view     |     [`View`](#ViewApi)     | The current view.                                                                                   |
 | resource | [`Resource`](#ResourceApi) | If the current view is a resource-view, the resource that owns this date.                           |
 
+#### `datesSet`
+
+Called after the calendar’s date range has been initially set or changed in some way and the DOM has been updated.
+
+Source: [https://fullcalendar.io/docs/datesSet](https://fullcalendar.io/docs/datesSet)
+
+| Property |            Type            | Description                                                                                                                             |
+| -------- | :------------------------: | --------------------------------------------------------------------------------------------------------------------------------------- |
+| start    |          `string`          | a date for the beginning of the range the calendar needs events for in [ISO8601 string](https://en.wikipedia.org/wiki/ISO_8601) format. |
+| end      |          `string`          | a date for the end of the range the calendar needs events for in [ISO8601 string](https://en.wikipedia.org/wiki/ISO_8601) format.       |
+| timeZone |          `string`          | the exact value of the calendar’s timeZone setting                                                                                    |
+| view     |     [`View`](#ViewApi)     | The current view.                                                                                                                       |
+
 #### `eventClick`
 
 Triggered when the user clicks an event.

--- a/streamlit_calendar/__init__.py
+++ b/streamlit_calendar/__init__.py
@@ -72,10 +72,10 @@ def calendar(
         nor use in commercial production websites or products if
         no license_key is provided.
     callbacks: str[]
-        List of callback to enable. By default all callbacks are enabled. 
-        Set to empty list to disable all callbacks.
-        List may contain 'dateClick', 'eventClick', 'eventChange', 'eventsSet'
-        and 'select'.
+        List of callbacks to enable. By default all callbacks are enabled except
+        for 'datesSet'. Set to empty list to disable all callbacks.
+        List may contain 'dateClick', 'datesSet', 'eventClick', 'eventChange',
+        'eventsSet' and 'select'.
     key: str or None
         An optional key that uniquely identifies this component. If this set to
         None, and the component's arguments are changed, the component will
@@ -84,10 +84,17 @@ def calendar(
     Returns
     -------
     dict
-        State value from dateClick, eventClick, eventChange, eventsSet
+        State value from dateClick, datesSet, eventClick, eventChange, eventsSet
         and select callback
 
     """
+
+    # Warn when eventsSet overwrites the datesSet callback
+    if "datesSet" in callbacks and "eventsSet" in callbacks:
+        warnings.warn("Both datesSet and eventsSet callbacks were requested. However, only one of the two can be triggered."
+                      "As such, only the eventsSet callback will be triggered. "
+                      "Remove the eventsSet from the callback list in order to receive datesSet callbacks.")
+
     # Call through to our private component function. Arguments we pass here
     # will be sent to the frontend, where they'll be available in an "args"
     # dictionary.

--- a/streamlit_calendar/frontend/src/components/Calendar.tsx
+++ b/streamlit_calendar/frontend/src/components/Calendar.tsx
@@ -15,6 +15,7 @@ import timelinePlugin from "@fullcalendar/timeline" // premium
 import {
   CalendarOptions,
   DateSelectArg,
+  DatesSetArg,
   EventApi,
   EventChangeArg,
   EventClickArg,
@@ -29,6 +30,8 @@ import {
   Callback,
   DateClickComponentValue,
   DateClickValue,
+  DatesSetComponentValue,
+  DatesSetValue,
   EventChangeComponentValue,
   EventChangeValue,
   EventClickComponentValue,
@@ -88,6 +91,22 @@ const CalendarFC: React.FC<Props> = ({
     const componentValue: DateClickComponentValue = {
       callback: "dateClick",
       dateClick,
+    }
+
+    Streamlit.setComponentValue(componentValue)
+  }
+
+  const handleDatesSet = (arg: DatesSetArg) => {
+    const datesSet: DatesSetValue = {
+      start: arg.start.toISOString(),
+      end: arg.end.toISOString(),
+      timeZone: arg.timeZone,
+      view: getViewValue(arg.view),
+    }
+
+    const componentValue: DatesSetComponentValue = {
+      callback: "datesSet",
+      datesSet,
     }
 
     Streamlit.setComponentValue(componentValue)
@@ -167,6 +186,9 @@ const CalendarFC: React.FC<Props> = ({
         schedulerLicenseKey={license_key}
         dateClick={
           callbacks?.includes("dateClick") ? handleDateClick : undefined
+        }
+        datesSet={
+          callbacks?.includes("datesSet") ? handleDatesSet : undefined
         }
         eventClick={
           callbacks?.includes("eventClick") ? handleEventClick : undefined

--- a/streamlit_calendar/frontend/src/types/Calendar.type.ts
+++ b/streamlit_calendar/frontend/src/types/Calendar.type.ts
@@ -47,6 +47,13 @@ export type DateClickValue = {
   resource?: ResourceValue
 }
 
+export type DatesSetValue = {
+  start: string
+  end: string
+  timeZone: string
+  view: ViewValue
+}
+
 export type EventClickValue = {
   event: EventValue
   view: ViewValue
@@ -75,6 +82,11 @@ export type DateClickComponentValue = {
   dateClick: DateClickValue
 }
 
+export type DatesSetComponentValue = {
+  callback: "datesSet"
+  datesSet: DatesSetValue
+}
+
 export type EventClickComponentValue = {
   callback: "eventClick"
   eventClick: EventClickValue
@@ -97,6 +109,7 @@ export type SelectComponentValue = {
 
 export type ComponentValue =
   | DateClickComponentValue
+  | DatesSetComponentValue
   | EventClickComponentValue
   | EventChangeComponentValue
   | EventsSetComponentValue


### PR DESCRIPTION
Hi Muhammad,

I noticed that the fullcalendar Streamlit component did not have a callback for date changes in the fullcalender yet. This is handy, for example, when the prev/next buttons are used in the calendar. As such, I implemented the fullcalendar's `datesSet` callback (https://fullcalendar.io/docs/datesSet) and wanted to share it.

For this update, I build upon your most recent release (22 dec 2023) and followed your style of coding (return format and variable naming).

One problem though: when the calendar’s dates change, both `datesSet` and `eventsSet` are triggered. I think setComponent causes only `eventsSet` to be triggered. As a result, the `datesSet` callback only works when there is no `eventsSet` callback requested. I added a warning in the component creation, but maybe you can think of a more elegant solution...

Best,
Max
