### PR TITLE
Add support for eventMouseEnter callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The properties of each callback are explained as follows:
 #### `eventMouseEnter`
 
 Triggered when the mouse enters an event element.
+Note: this callback is opt-in and is not enabled by default.
 
 | Property |         Type         | Description           |
 | -------- | :------------------: | --------------------- |

--- a/README.md
+++ b/README.md
@@ -135,7 +135,19 @@ st.write(calendar)
 # }
 ```
 
-The properties of each callback is explained as follows:
+
+The properties of each callback are explained as follows:
+
+#### `eventMouseEnter`
+
+Triggered when the mouse enters an event element.
+
+| Property |         Type         | Description           |
+| -------- | :------------------: | --------------------- |
+| event    | [`Event`](#EventApi) | The associated event. |
+| view     |  [`View`](#ViewApi)  | The current view.     |
+
+Source: [https://fullcalendar.io/docs/eventMouseEnter](https://fullcalendar.io/docs/eventMouseEnter)
 
 #### `dateClick`
 

--- a/streamlit_calendar/__init__.py
+++ b/streamlit_calendar/__init__.py
@@ -48,7 +48,7 @@ def calendar(
     events=[],
     options={},
     custom_css="",
-    callbacks=["dateClick", "eventClick", "eventChange", "eventsSet", "select"],
+    callbacks=["dateClick", "eventClick", "eventChange", "eventsSet", "select","eventMouseEnter"],
     license_key="CC-Attribution-NonCommercial-NoDerivatives",
     key=None,
 ):
@@ -72,10 +72,10 @@ def calendar(
         nor use in commercial production websites or products if
         no license_key is provided.
     callbacks: str[]
-        List of callback to enable. By default all callbacks are enabled. 
+        List of callback to enable. By default all callbacks are enabled.
         Set to empty list to disable all callbacks.
-        List may contain 'dateClick', 'eventClick', 'eventChange', 'eventsSet'
-        and 'select'.
+        List may contain 'dateClick', 'eventClick', 'eventChange', 'eventsSet',
+        'select' and 'eventMouseEnter'.
     key: str or None
         An optional key that uniquely identifies this component. If this set to
         None, and the component's arguments are changed, the component will

--- a/streamlit_calendar/__init__.py
+++ b/streamlit_calendar/__init__.py
@@ -48,7 +48,7 @@ def calendar(
     events=[],
     options={},
     custom_css="",
-    callbacks=["dateClick", "eventClick", "eventChange", "eventsSet", "select","eventMouseEnter"],
+    callbacks=["dateClick", "eventClick", "eventChange", "eventsSet", "select"],
     license_key="CC-Attribution-NonCommercial-NoDerivatives",
     key=None,
 ):
@@ -72,7 +72,8 @@ def calendar(
         nor use in commercial production websites or products if
         no license_key is provided.
     callbacks: str[]
-        List of callback to enable. By default all callbacks are enabled.
+        List of callback to enable. By default all 'dateClick', 'eventClick', 
+        'eventChange', 'eventsSet', and 'select' are enabled.
         Set to empty list to disable all callbacks.
         List may contain 'dateClick', 'eventClick', 'eventChange', 'eventsSet',
         'select' and 'eventMouseEnter'.
@@ -85,7 +86,7 @@ def calendar(
     -------
     dict
         State value from dateClick, eventClick, eventChange, eventsSet
-        and select callback
+        select, and eventMouseEnter callbacks. 
 
     """
     # Call through to our private component function. Arguments we pass here

--- a/streamlit_calendar/frontend/src/components/Calendar.tsx
+++ b/streamlit_calendar/frontend/src/components/Calendar.tsx
@@ -99,14 +99,20 @@ const CalendarFC: React.FC<Props> = ({
     Streamlit.setComponentValue(componentValue)
   }
 
+  // Use a WeakMap to associate elements with their listeners
+  const mouseEnterListeners = React.useRef(new WeakMap<HTMLElement, EventListener>()).current;
+
   // This is called by FullCalendar for each event after it is mounted
   const handleEventDidMount = (info: { event: EventApi; el: HTMLElement; view: ViewApi }) => {
     if (callbacks?.includes("eventMouseEnter")) {
       // Remove any previous listener to avoid duplicates
-      info.el.removeEventListener("mouseenter", (info.el as any)._stMouseEnterListener);
+      const prevListener = mouseEnterListeners.get(info.el);
+      if (prevListener) {
+        info.el.removeEventListener("mouseenter", prevListener);
+      }
       // Create and store the listener
       const listener = () => handleEventMouseEnter(info.event, info.view);
-      (info.el as any)._stMouseEnterListener = listener;
+      mouseEnterListeners.set(info.el, listener);
       info.el.addEventListener("mouseenter", listener);
     }
   }

--- a/streamlit_calendar/frontend/src/components/Calendar.tsx
+++ b/streamlit_calendar/frontend/src/components/Calendar.tsx
@@ -235,7 +235,9 @@ const CalendarFC: React.FC<Props> = ({
         select={
           callbacks?.includes("select") ? handleSelect : undefined
         }
-        eventDidMount={handleEventDidMount}
+        eventDidMount={
+          callbacks?.includes("eventMouseEnter") ? handleEventDidMount : undefined
+        }
         {...options}
       />
     </FullCalendarWrapper>

--- a/streamlit_calendar/frontend/src/components/Calendar.tsx
+++ b/streamlit_calendar/frontend/src/components/Calendar.tsx
@@ -34,6 +34,8 @@ import {
   EventChangeValue,
   EventClickComponentValue,
   EventClickValue,
+  EventMouseEnterComponentValue,
+  EventMouseEnterValue,
   EventsSetComponentValue,
   EventsSetValue,
   SelectComponentValue,
@@ -71,7 +73,7 @@ const CalendarFC: React.FC<Props> = ({
   args: { events, options, custom_css, callbacks, license_key },
 }) => {
   const calendarRef = useRef<FullCalendar>(null)
-  
+
   const getViewValue = (view: ViewApi): ViewValue => ({
     type: view.type,
     title: view.title,
@@ -80,7 +82,35 @@ const CalendarFC: React.FC<Props> = ({
     currentStart: view.currentStart.toISOString(),
     currentEnd: view.currentEnd.toISOString(),
   })
-  
+
+  // Attach native mouseenter event to event elements
+  const handleEventMouseEnter = (eventApi: EventApi, view: ViewApi) => {
+    const eventMouseEnter: EventMouseEnterValue = {
+      event: {
+        ...eventApi.toJSON(),
+        resourceId: eventApi.getResources()[0]?.id,
+      },
+      view: getViewValue(view),
+    }
+    const componentValue: EventMouseEnterComponentValue = {
+      callback: "eventMouseEnter",
+      eventMouseEnter,
+    }
+    Streamlit.setComponentValue(componentValue)
+  }
+
+  // This is called by FullCalendar for each event after it is mounted
+  const handleEventDidMount = (info: { event: EventApi; el: HTMLElement; view: ViewApi }) => {
+    if (callbacks?.includes("eventMouseEnter")) {
+      // Remove any previous listener to avoid duplicates
+      info.el.removeEventListener("mouseenter", (info.el as any)._stMouseEnterListener);
+      // Create and store the listener
+      const listener = () => handleEventMouseEnter(info.event, info.view);
+      (info.el as any)._stMouseEnterListener = listener;
+      info.el.addEventListener("mouseenter", listener);
+    }
+  }
+
   const handleDateClick = (arg: DateClickArg) => {
     const dateClick: DateClickValue = {
       allDay: arg.allDay,
@@ -199,6 +229,7 @@ const CalendarFC: React.FC<Props> = ({
         select={
           callbacks?.includes("select") ? handleSelect : undefined
         }
+        eventDidMount={handleEventDidMount}
         {...options}
       />
     </FullCalendarWrapper>

--- a/streamlit_calendar/frontend/src/types/Calendar.type.ts
+++ b/streamlit_calendar/frontend/src/types/Calendar.type.ts
@@ -52,6 +52,11 @@ export type EventClickValue = {
   view: ViewValue
 }
 
+export type EventMouseEnterValue = {
+  event: EventValue
+  view: ViewValue
+}
+
 export type EventChangeValue = {
   oldEvent: EventValue
   event: EventValue
@@ -82,6 +87,11 @@ export type EventClickComponentValue = {
   eventClick: EventClickValue
 }
 
+export type EventMouseEnterComponentValue = {
+  callback: "eventMouseEnter"
+  eventMouseEnter: EventMouseEnterValue
+}
+
 export type EventChangeComponentValue = {
   callback: "eventChange"
   eventChange: EventChangeValue
@@ -103,5 +113,6 @@ export type ComponentValue =
   | EventChangeComponentValue
   | EventsSetComponentValue
   | SelectComponentValue
+  | EventMouseEnterComponentValue
 
 export type Callback = ComponentValue["callback"]


### PR DESCRIPTION
These changes adds support for the eventMouseEnter callback from FullCalendar into streamlit_calendar component, closes #60. 

@im-perativa, I'd appreciate if you could review these changes as I believe this would be a long term viable solution but I am not 100% familiar with this ecosystem.